### PR TITLE
Map part_of to RO relation in OWL parser.

### DIFF
--- a/src/ontology/peco-edit.obo
+++ b/src/ontology/peco-edit.obo
@@ -5217,4 +5217,4 @@ is_a: PECO:0007115 ! Spodoptera spp. exposure
 [Typedef]
 id: part_of
 name: part of
-
+xref: BFO:0000050


### PR DESCRIPTION
Without the xref, the PECO 'part of' is not properly connected to RO when loaded as OWL.