### PR TITLE
Fix CAS cross-references

### DIFF
--- a/src/ontology/peco-edit.obo
+++ b/src/ontology/peco-edit.obo
@@ -2568,7 +2568,7 @@ is_a: PECO:0007196 ! light exposure
 id: PECO:0007204
 name: 1-naphthaleneacetic acid exposure
 alt_id: EO:0007204
-def: "An auxin exposure (PECO:0007074) involving use of 1-naphthaleneacetic acid growth hormone and herbicide." [CAS:\[68-87-3\], Gramene:pankaj_jaiswal]
+def: "An auxin exposure (PECO:0007074) involving use of 1-naphthaleneacetic acid growth hormone and herbicide." [CAS:68-87-3, Gramene:pankaj_jaiswal]
 synonym: "1-naphthaleneacetic acid treatment (narrow)" NARROW []
 synonym: "NAA (related)" RELATED []
 synonym: "Naphthylacetic acid (related)" RELATED []
@@ -4433,7 +4433,7 @@ is_a: PECO:0007414 ! peroxide exposure
 id: PECO:0007503
 name: 1,2-dibromoethane exposure
 alt_id: EO:0007503
-def: "The treatment involving use of 1,2-dibromoethane for mutagenesis process." [CAS:\[106-93-4\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of 1,2-dibromoethane for mutagenesis process." [CAS:106-93-4, Gramene:pankaj_jaiswal]
 synonym: "1,2-dibromoethane treatment (narrow)" NARROW []
 synonym: "DBE (related)" RELATED []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4442,7 +4442,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007504
 name: 1,2-dichloroethane exposure
 alt_id: EO:0007504
-def: "The treatment involving use of 1,2-dichloroethane for mutagenesis process." [CAS:\[107-06-2\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of 1,2-dichloroethane for mutagenesis process." [CAS:107-06-2, Gramene:pankaj_jaiswal]
 synonym: "1,2-dichloroethane treatment (narrow)" NARROW []
 synonym: "DCE (related)" RELATED []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4451,7 +4451,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007505
 name: 1,2:5,6-dibenzanthracene exposure
 alt_id: EO:0007505
-def: "The treatment involving use of 1,2:5,6-dibenzanthracene for mutagenesis process." [CAS:\[53-70-3\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of 1,2:5,6-dibenzanthracene for mutagenesis process." [CAS:53-70-3, Gramene:pankaj_jaiswal]
 synonym: "1,2:5,6-dibenzanthracene treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4459,7 +4459,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007506
 name: 1,4-dimethanesulfonoxy-1:4-dimethylbutane exposure
 alt_id: EO:0007506
-def: "The treatment involving use of 1,4-dimethanesulfonoxy-1:4-dimethylbutane for mutagenesis process." [CAS:\[2514-83-2\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of 1,4-dimethanesulfonoxy-1:4-dimethylbutane for mutagenesis process." [CAS:2514-83-2, Gramene:pankaj_jaiswal]
 synonym: "1,4-dimethanesulfonoxy-1:4-dimethylbutane treatment (narrow)" NARROW []
 synonym: "CB2348 (related)" RELATED []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4468,7 +4468,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007507
 name: 1,4-dimethanesulfonoxybut-2-yne exposure
 alt_id: EO:0007507
-def: "The treatment involving use of 1,4-dimethanesulfonoxybut-2-yne for mutagenesis process." [CAS:\[2917-96-6\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of 1,4-dimethanesulfonoxybut-2-yne for mutagenesis process." [CAS:2917-96-6, Gramene:pankaj_jaiswal]
 synonym: "1,4-dimethanesulfonoxybut-2-yne treatment (narrow)" NARROW []
 synonym: "CB2058 (related)" RELATED []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4477,7 +4477,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007508
 name: 1,4-dimethanesulfonoxybutane exposure
 alt_id: EO:0007508
-def: "The treatment involving use of 1,4-dimethanesulfonoxybutane for mutagenesis process." [CAS:\[55-98-1\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of 1,4-dimethanesulfonoxybutane for mutagenesis process." [CAS:55-98-1, Gramene:pankaj_jaiswal]
 synonym: "1,4-dimethanesulfonoxybutane treatment (narrow)" NARROW []
 synonym: "busulfan (related)" RELATED []
 synonym: "CB2041 (related)" RELATED []
@@ -4487,7 +4487,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007509
 name: 1,6-dimethylsulfonoxy D-mannitol exposure
 alt_id: EO:0007509
-def: "The treatment involving use of 1,6-dimethylsulfonoxy D-mannitol for mutagenesis process." [CAS:\[1187-00-4\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of 1,6-dimethylsulfonoxy D-mannitol for mutagenesis process." [CAS:1187-00-4, Gramene:pankaj_jaiswal]
 synonym: "1,6-dimethylsulfonoxy D-mannitol treatment (narrow)" NARROW []
 synonym: "CB2511 (related)" RELATED []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4496,7 +4496,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007510
 name: 1,6-dimethylsulfonoxy L-mannitol exposure
 alt_id: EO:0007510
-def: "The treatment involving use of 1,6-dimethylsulfonoxy L-mannitol for mutagenesis process." [CAS:\[2514-83-2\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of 1,6-dimethylsulfonoxy L-mannitol for mutagenesis process." [CAS:2514-83-2, Gramene:pankaj_jaiswal]
 synonym: "1,6-dimethylsulfonoxy L-mannitol treatment (narrow)" NARROW []
 synonym: "CB2628 (related)" RELATED []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4505,7 +4505,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007511
 name: 1-amino-2-naphthol-4-sulfonic acid exposure
 alt_id: EO:0007511
-def: "The treatment involving use of 1-amino-2-naphthol-4-sulfonic acid for mutagenesis process." [CAS:\[116-63-2\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of 1-amino-2-naphthol-4-sulfonic acid for mutagenesis process." [CAS:116-63-2, Gramene:pankaj_jaiswal]
 synonym: "1-amino-2-naphthol-4-sulfonic acid treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4513,7 +4513,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007512
 name: 1-bromo-2-chloroethane exposure
 alt_id: EO:0007512
-def: "The treatment involving use of 1-bromo-2-chloroethane for mutagenesis process." [CAS:\[107-04-0\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of 1-bromo-2-chloroethane for mutagenesis process." [CAS:107-04-0, Gramene:pankaj_jaiswal]
 synonym: "1-bromo-2-chloroethane treatment (narrow)" NARROW []
 synonym: "BCE (related)" RELATED []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4522,7 +4522,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007513
 name: 1-diethylaminoethylethylamino-4-methyl-thioxanthenone exposure
 alt_id: EO:0007513
-def: "The treatment involving use of 1-diethylaminoethylethylamino-4-methyl-thioxanthenone for mutagenesis process." [CAS:\[479-50-5\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of 1-diethylaminoethylethylamino-4-methyl-thioxanthenone for mutagenesis process." [CAS:479-50-5, Gramene:pankaj_jaiswal]
 synonym: "1-diethylaminoethylethylamino-4-methyl-thioxanthenone treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4530,7 +4530,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007514
 name: 2,5,-bisethylene-imine-1,4-benzoquinone exposure
 alt_id: EO:0007514
-def: "The treatment involving use of 2,5,-bisethylene-imine-1,4-benzoquinone for mutagenesis process." [CAS:\[526-62-5\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of 2,5,-bisethylene-imine-1,4-benzoquinone for mutagenesis process." [CAS:526-62-5, Gramene:pankaj_jaiswal]
 synonym: "2,5,-bisethylene-imine-1,4-benzoquinone treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4538,7 +4538,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007515
 name: 2-chloroethyl methanesulfonate exposure
 alt_id: EO:0007515
-def: "The treatment involving use of 2-chloroethyl methanesulfonate for mutagenesis process." [CAS:\[3570-58-9\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of 2-chloroethyl methanesulfonate for mutagenesis process." [CAS:3570-58-9, Gramene:pankaj_jaiswal]
 synonym: "2-chloroethyl methanesulfonate treatment (narrow)" NARROW []
 synonym: "CB1506 (related)" RELATED []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4547,7 +4547,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007516
 name: 2-fluoroethyl methanesulfonate exposure
 alt_id: EO:0007516
-def: "The treatment involving use of 2-fluoroethyl methanesulfonate for mutagenesis process." [CAS:\[461-31-4\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of 2-fluoroethyl methanesulfonate for mutagenesis process." [CAS:461-31-4, Gramene:pankaj_jaiswal]
 synonym: "2-fluoroethyl methanesulfonate treatment (narrow)" NARROW []
 synonym: "CB1522 (related)" RELATED []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4556,7 +4556,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007517
 name: 2-methoxyethanol exposure
 alt_id: EO:0007517
-def: "The treatment involving use of 2-methoxyethanol for mutagenesis process." [CAS:\[109-86-4\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of 2-methoxyethanol for mutagenesis process." [CAS:109-86-4, Gramene:pankaj_jaiswal]
 synonym: "2-methoxyethanol treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4564,7 +4564,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007518
 name: 5-bromouracil exposure
 alt_id: EO:0007518
-def: "The treatment involving use of 5-bromouracil for mutagenesis process." [CAS:\[51-20-7\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of 5-bromouracil for mutagenesis process." [CAS:51-20-7, Gramene:pankaj_jaiswal]
 synonym: "5-bromouracil treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4572,7 +4572,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007519
 name: 5-bromouridine exposure
 alt_id: EO:0007519
-def: "The treatment involving use of 5-bromouridine for mutagenesis process." [CAS:\[957-75-5\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of 5-bromouridine for mutagenesis process." [CAS:957-75-5, Gramene:pankaj_jaiswal]
 synonym: "5-bromouridine treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4580,7 +4580,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007520
 name: 7-bromomethyl 12 methyl benz or agr/anthracine exposure
 alt_id: EO:0007520
-def: "The treatment involving use of 7-bromomethyl 12 methyl benz or agr/anthracine for mutagenesis process." [CAS:\[16238-56-5\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of 7-bromomethyl 12 methyl benz or agr/anthracine for mutagenesis process." [CAS:16238-56-5, Gramene:pankaj_jaiswal]
 synonym: "7-bromomethyl 12 methyl benz or agr/anthracine treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4588,7 +4588,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007521
 name: actinomycin D exposure
 alt_id: EO:0007521
-def: "An antibiotic exposure (PECO:0007041) involving use of actinomycin D for mutagenesis process." [CAS:\[50-76-0\], Gramene:pankaj_jaiswal, TO:moorel]
+def: "An antibiotic exposure (PECO:0007041) involving use of actinomycin D for mutagenesis process." [CAS:50-76-0, Gramene:pankaj_jaiswal, TO:moorel]
 synonym: "actinomycin D treatment (narrow)" NARROW []
 xref: PECO_GIT:69
 is_a: PECO:0007041 ! antibiotic exposure
@@ -4598,7 +4598,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007522
 name: aminopterin exposure
 alt_id: EO:0007522
-def: "The treatment involving use of aminopterin for mutagenesis process." [CAS:\[54-62-6\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of aminopterin for mutagenesis process." [CAS:54-62-6, Gramene:pankaj_jaiswal]
 synonym: "aminopterin treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4606,7 +4606,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007523
 name: benzo (or agr)pyrene exposure
 alt_id: EO:0007523
-def: "The treatment involving use of benzo (or agr)pyrene for mutagenesis process." [CAS:\[50-32-8\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of benzo (or agr)pyrene for mutagenesis process." [CAS:50-32-8, Gramene:pankaj_jaiswal]
 synonym: "benzo (or agr)pyrene treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4614,7 +4614,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007524
 name: caffeine exposure
 alt_id: EO:0007524
-def: "The treatment involving use of caffeine for mutagenesis process." [CAS:\[58-08-2\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of caffeine for mutagenesis process." [CAS:58-08-2, Gramene:pankaj_jaiswal]
 synonym: "caffeine treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4622,7 +4622,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007525
 name: cisplatin exposure
 alt_id: EO:0007525
-def: "The treatment involving use of cisplatin for mutagenesis process." [CAS:\[15663-27-1\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of cisplatin for mutagenesis process." [CAS:15663-27-1, Gramene:pankaj_jaiswal]
 synonym: "cis-dichlorodiammineplatinum(II) (related)" RELATED []
 synonym: "cisplatin treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4631,7 +4631,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007526
 name: colchicine exposure
 alt_id: EO:0007526
-def: "The treatment involving use of colchicine for mutagenesis process." [CAS:\[64-86-8\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of colchicine for mutagenesis process." [CAS:64-86-8, Gramene:pankaj_jaiswal]
 synonym: "colchicine treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4639,7 +4639,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007527
 name: cupric sulfate exposure
 alt_id: EO:0007527
-def: "The treatment involving use of cupric sulfate for mutagenesis process." [CAS:\[7758-98-7\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of cupric sulfate for mutagenesis process." [CAS:7758-98-7, Gramene:pankaj_jaiswal]
 synonym: "cupric sulfate treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4647,7 +4647,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007528
 name: diepoxybutane exposure
 alt_id: EO:0007528
-def: "The treatment involving use of diepoxybutane for mutagenesis process." [CAS:\[1464-53-5\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of diepoxybutane for mutagenesis process." [CAS:1464-53-5, Gramene:pankaj_jaiswal]
 synonym: "DEB (related)" RELATED []
 synonym: "diepoxybutane treatment (narrow)" NARROW []
 synonym: "erythritol anhydride (related)" RELATED []
@@ -4657,7 +4657,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007529
 name: diepoxyoctane exposure
 alt_id: EO:0007529
-def: "The treatment involving use of diepoxyoctane for mutagenesis process." [CAS:\[2426-07-5\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of diepoxyoctane for mutagenesis process." [CAS:2426-07-5, Gramene:pankaj_jaiswal]
 synonym: "diepoxyoctane treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4665,7 +4665,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007530
 name: diethyl sulfate exposure
 alt_id: EO:0007530
-def: "The treatment involving use of diethyl sulfate for mutagenesis process." [CAS:\[64-67-5\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of diethyl sulfate for mutagenesis process." [CAS:64-67-5, Gramene:pankaj_jaiswal]
 synonym: "DES (related)" RELATED []
 synonym: "diethyl sulfate treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4674,7 +4674,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007531
 name: dimethyl sulfoxide exposure
 alt_id: EO:0007531
-def: "The treatment involving use of dimthyl sulfate for mutagenesis process." [CAS:\[67-68-5\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of dimthyl sulfate for mutagenesis process." [CAS:67-68-5, Gramene:pankaj_jaiswal]
 synonym: "dimethyl sulfoxide treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4682,7 +4682,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007532
 name: DNA exposure
 alt_id: EO:0007532
-def: "The treatment involving use of DNA fragment insertion or deletion as part of mutagenesis." [CAS:\[9007-49-2\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of DNA fragment insertion or deletion as part of mutagenesis." [CAS:9007-49-2, Gramene:pankaj_jaiswal]
 synonym: "DNA treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4690,7 +4690,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007533
 name: ethyl ether exposure
 alt_id: EO:0007533
-def: "The treatment involving use of ethyl ether for mutagenesis process." [CAS:\[60-29-7\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of ethyl ether for mutagenesis process." [CAS:60-29-7, Gramene:pankaj_jaiswal]
 synonym: "ethyl ether treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4698,7 +4698,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007534
 name: ethyl methanesulfonate exposure
 alt_id: EO:0007534
-def: "The treatment involving use of EMS as a mutagen by damaging DNA and is used experimentally for that effect." [CAS:\[62-50-0\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of EMS as a mutagen by damaging DNA and is used experimentally for that effect." [CAS:62-50-0, Gramene:pankaj_jaiswal]
 synonym: "CB1528 (related)" RELATED []
 synonym: "EMS (related)" RELATED []
 synonym: "ethyl methanesulfonate treatment (narrow)" NARROW []
@@ -4709,7 +4709,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007535
 name: ethyl nitrosourea exposure
 alt_id: EO:0007535
-def: "The treatment involving use of ethyl nitrosourea for mutagenesis process." [CAS:\[759-73-9\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of ethyl nitrosourea for mutagenesis process." [CAS:759-73-9, Gramene:pankaj_jaiswal]
 synonym: "ENU (related)" RELATED []
 synonym: "ethyl nitrosourea treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4726,7 +4726,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007537
 name: ethylenimine exposure
 alt_id: EO:0007537
-def: "The treatment involving use of ethylenimine for mutagenesis process." [CAS:\[151-56-4\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of ethylenimine for mutagenesis process." [CAS:151-56-4, Gramene:pankaj_jaiswal]
 synonym: "EI (related)" RELATED []
 synonym: "ethylenimine treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4743,7 +4743,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007539
 name: formaldehyde exposure
 alt_id: EO:0007539
-def: "The treatment involving use of formaldehyde for mutagenesis process." [CAS:\[50-00-0\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of formaldehyde for mutagenesis process." [CAS:50-00-0, Gramene:pankaj_jaiswal]
 synonym: "formaldehyde treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4760,7 +4760,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007541
 name: hesperidine exposure
 alt_id: EO:0007541
-def: "The treatment involving use of hesperidine for mutagenesis process." [CAS:\[520-26-3\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of hesperidine for mutagenesis process." [CAS:520-26-3, Gramene:pankaj_jaiswal]
 synonym: "hesperidine treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4768,7 +4768,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007542
 name: hexamethylmelamine exposure
 alt_id: EO:0007542
-def: "The treatment involving use of hexamethylmelamine for mutagenesis process." [CAS:\[645-05-6\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of hexamethylmelamine for mutagenesis process." [CAS:645-05-6, Gramene:pankaj_jaiswal]
 synonym: "altretamine (related)" RELATED []
 synonym: "hexamethylmelamine treatment (narrow)" NARROW []
 synonym: "HMM (related)" RELATED []
@@ -4778,7 +4778,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007543
 name: hexamethylphosphoramide exposure
 alt_id: EO:0007543
-def: "The treatment involving use of hexamethylphosphoramide for mutagenesis process." [CAS:\[680-31-9\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of hexamethylphosphoramide for mutagenesis process." [CAS:680-31-9, Gramene:pankaj_jaiswal]
 synonym: "hexamethylphosphoramide treatment (narrow)" NARROW []
 synonym: "HMPA (related)" RELATED []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4787,7 +4787,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007544
 name: hycanthon methanesulfonate exposure
 alt_id: EO:0007544
-def: "The treatment involving use of hycanthon methanesulfonate for mutagenesis process." [CAS:\[23255-93-8\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of hycanthon methanesulfonate for mutagenesis process." [CAS:23255-93-8, Gramene:pankaj_jaiswal]
 synonym: "HMS (related)" RELATED []
 synonym: "hycanthon methanesulfonate treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4796,7 +4796,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007545
 name: ICR 100 exposure
 alt_id: EO:0007545
-def: "The treatment involving use of ICR 100 for mutagenesis process." [CAS:\[4213-45-0\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of ICR 100 for mutagenesis process." [CAS:4213-45-0, Gramene:pankaj_jaiswal]
 synonym: "2-methoxy-6-[3-(ethyl-2-chloroethyl)aminopropylamino]acridine (related)" RELATED []
 synonym: "ICR 100 treatment (narrow)" NARROW []
 synonym: "quinacrine mustard (related)" RELATED []
@@ -4806,7 +4806,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007546
 name: ICR 170 exposure
 alt_id: EO:0007546
-def: "The treatment involving use of ICR 170 for mutagenesis process." [CAS:\[146-59-8\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of ICR 170 for mutagenesis process." [CAS:146-59-8, Gramene:pankaj_jaiswal]
 synonym: "2-methoxy-6-dichloro-9-(3-ethyl-2-chloroethyl-aminopropylamino)acridine-dihydrochloride (related)" RELATED []
 synonym: "ICR 170 treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4815,7 +4815,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007547
 name: iodine exposure
 alt_id: EO:0007547
-def: "The treatment involving use of iodine for mutagenesis process." [CAS:\[7553-56-2\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of iodine for mutagenesis process." [CAS:7553-56-2, Gramene:pankaj_jaiswal]
 synonym: "iodine treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4823,7 +4823,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007548
 name: Janus green B exposure
 alt_id: EO:0007548
-def: "The treatment involving use of Janus green B for mutagenesis process." [CAS:\[2869-83-2\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of Janus green B for mutagenesis process." [CAS:2869-83-2, Gramene:pankaj_jaiswal]
 synonym: "Janus green B treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4839,7 +4839,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007550
 name: methyl methanesulfonate exposure
 alt_id: EO:0007550
-def: "The treatment involving use of methyl methanesulfonate for mutagenesis process." [CAS:\[66-27-3\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of methyl methanesulfonate for mutagenesis process." [CAS:66-27-3, Gramene:pankaj_jaiswal]
 synonym: "CB1540 (related)" RELATED []
 synonym: "methyl methanesulfonate treatment (narrow)" NARROW []
 synonym: "MMS (related)" RELATED []
@@ -4849,7 +4849,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007551
 name: mitomycin C exposure
 alt_id: EO:0007551
-def: "An antibiotic exposure (PECO:0007551) involving use of mitomycin C for mutagenesis process." [CAS:\[50-07-7\], Gramene:pankaj_jaiswal, TO:moorel]
+def: "An antibiotic exposure (PECO:0007551) involving use of mitomycin C for mutagenesis process." [CAS:50-07-7, Gramene:pankaj_jaiswal, TO:moorel]
 synonym: "mitomycin C treatment (narrow)" NARROW []
 xref: PECO_GIT:69
 is_a: PECO:0007041 ! antibiotic exposure
@@ -4859,7 +4859,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007552
 name: mustard gas exposure
 alt_id: EO:0007552
-def: "The treatment involving use of mustard gas for mutagenesis process." [CAS:\[505-60-2\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of mustard gas for mutagenesis process." [CAS:505-60-2, Gramene:pankaj_jaiswal]
 synonym: "1,1'-thiobis[2-chloroethane (related)" RELATED []
 synonym: "mustard gas treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4868,7 +4868,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007553
 name: N-methyl-N'-nitro-N-nitrosoguanidine exposure
 alt_id: EO:0007553
-def: "The treatment involving use of N-methyl-N'-nitro-N-nitrosoguanidine for mutagenesis process." [CAS:\[70-25-7\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of N-methyl-N'-nitro-N-nitrosoguanidine for mutagenesis process." [CAS:70-25-7, Gramene:pankaj_jaiswal]
 synonym: "MNNG (related)" RELATED []
 synonym: "N-methyl-N'-nitro-N-nitrosoguanidine treatment (narrow)" NARROW []
 synonym: "NNG (related)" RELATED []
@@ -4878,7 +4878,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007554
 name: N-nitrosodimethylamine exposure
 alt_id: EO:0007554
-def: "The treatment involving use of N-nitrosodimethylamine for mutagenesis process." [CAS:\[62-75-9\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of N-nitrosodimethylamine for mutagenesis process." [CAS:62-75-9, Gramene:pankaj_jaiswal]
 synonym: "DMN (related)" RELATED []
 synonym: "N-nitrosodimethylamine treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4895,7 +4895,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007556
 name: nitrogen mustard exposure
 alt_id: EO:0007556
-def: "The treatment involving use of nitrogen mustard for mutagenesis process." [CAS:\[51-75-2\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of nitrogen mustard for mutagenesis process." [CAS:51-75-2, Gramene:pankaj_jaiswal]
 synonym: "2-chloro-N-(2-chloroethyl)-N-methylethanamine (related)" RELATED []
 synonym: "CB1414 (related)" RELATED []
 synonym: "HN2 (related)" RELATED []
@@ -4907,7 +4907,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007557
 name: nitrosomethyl urea exposure
 alt_id: EO:0007557
-def: "The treatment involving use of nitrosomethyl urea for mutagenesis process." [CAS:\[684-93-5\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of nitrosomethyl urea for mutagenesis process." [CAS:684-93-5, Gramene:pankaj_jaiswal]
 synonym: "MNU (related)" RELATED []
 synonym: "N-methyl-N-nitrosourea (related)" RELATED []
 synonym: "nitrosomethyl urea treatment (narrow)" NARROW []
@@ -4917,7 +4917,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007558
 name: p-N,N-di(2-chloroethyl)aminophenylvaleric acid exposure
 alt_id: EO:0007558
-def: "The treatment involving use of p-N,N-di(2-chloroethyl)aminophenylvaleric acid for mutagenesis process." [CAS:\[64508-90-3\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of p-N,N-di(2-chloroethyl)aminophenylvaleric acid for mutagenesis process." [CAS:64508-90-3, Gramene:pankaj_jaiswal]
 synonym: "CB1356 (related)" RELATED []
 synonym: "p-N,N-di(2-chloroethyl)aminophenylvaleric acid treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4926,7 +4926,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007559
 name: p-N,N-di-(2-chloroethyl)amino-D-phenylalanine exposure
 alt_id: EO:0007559
-def: "The treatment involving use of p-N,N-di-(2-chloroethyl)amino-D-phenylalanine for mutagenesis process." [CAS:\[13045-94-8\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of p-N,N-di-(2-chloroethyl)amino-D-phenylalanine for mutagenesis process." [CAS:13045-94-8, Gramene:pankaj_jaiswal]
 synonym: "CB3026 (related)" RELATED []
 synonym: "p-N,N-di-(2-chloroethyl)amino-D-phenylalanine treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4935,7 +4935,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007560
 name: p-N,N-di-(2-chloroethyl)amino-DL-phenylalanine exposure
 alt_id: EO:0007560
-def: "The treatment involving use of p-N,N-di-(2-chloroethyl)amino-DL-phenylalanine for mutagenesis process." [CAS:\[148-82-3\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of p-N,N-di-(2-chloroethyl)amino-DL-phenylalanine for mutagenesis process." [CAS:148-82-3, Gramene:pankaj_jaiswal]
 synonym: "CB3007 (related)" RELATED []
 synonym: "melphalan (related)" RELATED []
 synonym: "p-N,N-di-(2-chloroethyl)amino-DL-phenylalanine treatment (narrow)" NARROW []
@@ -4954,7 +4954,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007562
 name: p-N,N-di-(2-chloroethyl)aminophenylbutyric acid exposure
 alt_id: EO:0007562
-def: "The treatment involving use of p-N,N-di-(2-chloroethyl)aminophenylbutyric acid for mutagenesis process." [CAS:\[305-03-3\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of p-N,N-di-(2-chloroethyl)aminophenylbutyric acid for mutagenesis process." [CAS:305-03-3, Gramene:pankaj_jaiswal]
 synonym: "CB1348 (related)" RELATED []
 synonym: "chlorambucil (related)" RELATED []
 synonym: "p-N,N-di-(2-chloroethyl)aminophenylbutyric acid treatment (narrow)" NARROW []
@@ -4964,7 +4964,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007563
 name: p-N,N-di-(2-chloroethyl)aminophenylethylamine exposure
 alt_id: EO:0007563
-def: "The treatment involving use of p-N,N-di-(2-chloroethyl)aminophenylethylamine for mutagenesis process." [CAS:\[58880-18-5\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of p-N,N-di-(2-chloroethyl)aminophenylethylamine for mutagenesis process." [CAS:58880-18-5, Gramene:pankaj_jaiswal]
 synonym: "CB3034 (related)" RELATED []
 synonym: "p-N,N-di-(2-chloroethyl)aminophenylethylamine treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4973,7 +4973,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007564
 name: p-p'-N,N-di(2-chloroethyl)aminophenoxyphenylalanine exposure
 alt_id: EO:0007564
-def: "The treatment involving use of p-p'-N,N-di(2-chloroethyl)aminophenoxyphenylalanine for mutagenesis process." [CAS:\[857-95-4\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of p-p'-N,N-di(2-chloroethyl)aminophenoxyphenylalanine for mutagenesis process." [CAS:857-95-4, Gramene:pankaj_jaiswal]
 synonym: "CB3051 (related)" RELATED []
 synonym: "p-p'-N,N-di(2-chloroethyl)aminophenoxyphenylalanine treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4982,7 +4982,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007565
 name: quinhydrone exposure
 alt_id: EO:0007565
-def: "The treatment involving use of quinhydrone for mutagenesis process." [CAS:\[106-34-3\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of quinhydrone for mutagenesis process." [CAS:106-34-3, Gramene:pankaj_jaiswal]
 synonym: "quinhydrone treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -4990,7 +4990,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007566
 name: S-2-chloroethylcysteine exposure
 alt_id: EO:0007566
-def: "The treatment involving use of S-2-chloroethylcysteine for mutagenesis process." [CAS:\[28361-96-8\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of S-2-chloroethylcysteine for mutagenesis process." [CAS:28361-96-8, Gramene:pankaj_jaiswal]
 synonym: "CB1592 (related)" RELATED []
 synonym: "S-2-chloroethylcysteine treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -4999,7 +4999,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007567
 name: sodium bisulfite exposure
 alt_id: EO:0007567
-def: "The treatment involving use of sodium bisulfite for mutagenesis process." [CAS:\[7631-90-5\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of sodium bisulfite for mutagenesis process." [CAS:7631-90-5, Gramene:pankaj_jaiswal]
 synonym: "sodium bisulfite treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -5007,7 +5007,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007568
 name: sodium fluoride exposure
 alt_id: EO:0007568
-def: "The treatment involving use of sodium fluoride for mutagenesis process." [CAS:\[7681-49-4\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of sodium fluoride for mutagenesis process." [CAS:7681-49-4, Gramene:pankaj_jaiswal]
 synonym: "sodium fluoride treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -5024,7 +5024,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007570
 name: sulfur mustard exposure
 alt_id: EO:0007570
-def: "The treatment involving use of sulfur mustard for mutagenesis process." [CAS:\[505-60-2\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of sulfur mustard for mutagenesis process." [CAS:505-60-2, Gramene:pankaj_jaiswal]
 synonym: "CB1735 (related)" RELATED []
 synonym: "sulfur mustard treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
@@ -5033,7 +5033,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007571
 name: triaziquone exposure
 alt_id: EO:0007571
-def: "The treatment involving use of triaziquone for mutagenesis process." [CAS:\[68-76-8\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of triaziquone for mutagenesis process." [CAS:68-76-8, Gramene:pankaj_jaiswal]
 synonym: "triaziquone treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -5041,7 +5041,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007572
 name: triethylenemelamine exposure
 alt_id: EO:0007572
-def: "The treatment involving use of triethylenemelamine for mutagenesis process." [CAS:\[51-18-3\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of triethylenemelamine for mutagenesis process." [CAS:51-18-3, Gramene:pankaj_jaiswal]
 synonym: "CB1246 (related)" RELATED []
 synonym: "TEM (related)" RELATED []
 synonym: "triethylenemelamine treatment (narrow)" NARROW []
@@ -5051,7 +5051,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007573
 name: urethane exposure
 alt_id: EO:0007573
-def: "The treatment involving use of urethane for mutagenesis process." [CAS:\[51-79-6\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of urethane for mutagenesis process." [CAS:51-79-6, Gramene:pankaj_jaiswal]
 synonym: "urethane treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 
@@ -5059,7 +5059,7 @@ is_a: PECO:0007149 ! chemical mutagen exposure
 id: PECO:0007574
 name: vinyl carbamate exposure
 alt_id: EO:0007574
-def: "The treatment involving use of vinyl carbamate for mutagenesis process." [CAS:\[15805-73-9\], Gramene:pankaj_jaiswal]
+def: "The treatment involving use of vinyl carbamate for mutagenesis process." [CAS:15805-73-9, Gramene:pankaj_jaiswal]
 synonym: "vinyl carbamate treatment (narrow)" NARROW []
 is_a: PECO:0007149 ! chemical mutagen exposure
 


### PR DESCRIPTION
CAS numbers that were written with escaped brackets `CAS:\[106-93-4\]` were fixed to not include brackets nor escapes like `CAS:106-93-4`. There were about 60 cases where this was fixed.